### PR TITLE
Cleanup MDComponents allocations and event handlers

### DIFF
--- a/Checkbox/Checkbox.jsx
+++ b/Checkbox/Checkbox.jsx
@@ -14,7 +14,7 @@ export default class Checkbox extends MaterialComponent {
     this.MDComponent = new MDCCheckbox(this.control);
   }
   componentWillUnmount() {
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(allprops) {
     const { className, ...props } = allprops;

--- a/Checkbox/Checkbox.jsx
+++ b/Checkbox/Checkbox.jsx
@@ -13,6 +13,9 @@ export default class Checkbox extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCCheckbox(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(allprops) {
     const { className, ...props } = allprops;
     return (

--- a/Checkbox/index.js
+++ b/Checkbox/index.js
@@ -37,6 +37,9 @@ export default class Checkbox extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCCheckbox(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(allprops) {
     const { className } = allprops,
       props = _objectWithoutProperties(allprops, ["className"]);

--- a/Dialog/Dialog.jsx
+++ b/Dialog/Dialog.jsx
@@ -12,6 +12,9 @@ class Dialog extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCDialog(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return (
       <aside

--- a/Dialog/Dialog.jsx
+++ b/Dialog/Dialog.jsx
@@ -13,7 +13,7 @@ class Dialog extends MaterialComponent {
     this.MDComponent = new MDCDialog(this.control);
   }
   componentWillUnmount() {
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(props) {
     return (

--- a/Dialog/index.js
+++ b/Dialog/index.js
@@ -26,6 +26,9 @@ class Dialog extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCDialog(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return h(
       "aside",

--- a/Drawer/Drawer.jsx
+++ b/Drawer/Drawer.jsx
@@ -29,6 +29,7 @@ class TemporaryDrawer extends MaterialComponent {
   componentWillUnmount() {
     this.MDComponent.unlisten("MDCTemporaryDrawer:close", this._close);
     this.MDComponent.unlisten("MDCTemporaryDrawer:open", this._open);
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(props) {
     return (
@@ -136,6 +137,7 @@ class PersistentDrawer extends MaterialComponent {
   componentWillUnmount() {
     this.MDComponent.unlisten("MDCPersistentDrawer:close", this._close);
     this.MDComponent.unlisten("MDCPersistentDrawer:open", this._open);
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(props) {
     return (

--- a/Drawer/Drawer.jsx
+++ b/Drawer/Drawer.jsx
@@ -8,20 +8,27 @@ class TemporaryDrawer extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "temporary-drawer";
+    this._open = this._open.bind(this);
+    this._close = this._close.bind(this);
+  }
+  _open() {
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  }
+  _close() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   }
   componentDidMount() {
     this.MDComponent = MDCTemporaryDrawer.attachTo(this.control);
-    this.MDComponent.listen("MDCTemporaryDrawer:open", () => {
-      if (this.props.onOpen) {
-        this.props.onOpen();
-      }
-    });
-
-    this.MDComponent.listen("MDCTemporaryDrawer:close", () => {
-      if (this.props.onClose) {
-        this.props.onClose();
-      }
-    });
+    this.MDComponent.listen("MDCTemporaryDrawer:open", this._open);
+    this.MDComponent.listen("MDCTemporaryDrawer:close", this._close);
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCTemporaryDrawer:close", this._close);
+    this.MDComponent.unlisten("MDCTemporaryDrawer:open", this._open);
   }
   materialDom(props) {
     return (
@@ -108,20 +115,27 @@ class PersistentDrawer extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "persistent-drawer";
+    this._open = this._open.bind(this);
+    this._close = this._close.bind(this);
+  }
+  _open() {
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  }
+  _close() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   }
   componentDidMount() {
     this.MDComponent = MDCPersistentDrawer.attachTo(this.control);
-    this.MDComponent.listen("MDCPersistentDrawer:open", () => {
-      if (this.props.onOpen) {
-        this.props.onOpen();
-      }
-    });
-
-    this.MDComponent.listen("MDCPersistentDrawer:close", () => {
-      if (this.props.onClose) {
-        this.props.onClose();
-      }
-    });
+    this.MDComponent.listen("MDCPersistentDrawer:open", this._open);
+    this.MDComponent.listen("MDCPersistentDrawer:close", this._close);
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCPersistentDrawer:close", this._close);
+    this.MDComponent.unlisten("MDCPersistentDrawer:open", this._open);
   }
   materialDom(props) {
     return (

--- a/Drawer/index.js
+++ b/Drawer/index.js
@@ -22,20 +22,27 @@ class TemporaryDrawer extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "temporary-drawer";
+    this._open = this._open.bind(this);
+    this._close = this._close.bind(this);
+  }
+  _open() {
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  }
+  _close() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   }
   componentDidMount() {
     this.MDComponent = MDCTemporaryDrawer.attachTo(this.control);
-    this.MDComponent.listen("MDCTemporaryDrawer:open", () => {
-      if (this.props.onOpen) {
-        this.props.onOpen();
-      }
-    });
-
-    this.MDComponent.listen("MDCTemporaryDrawer:close", () => {
-      if (this.props.onClose) {
-        this.props.onClose();
-      }
-    });
+    this.MDComponent.listen("MDCTemporaryDrawer:open", this._open);
+    this.MDComponent.listen("MDCTemporaryDrawer:close", this._close);
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCTemporaryDrawer:close", this._close);
+    this.MDComponent.unlisten("MDCTemporaryDrawer:open", this._open);
   }
   materialDom(props) {
     return h(
@@ -128,20 +135,27 @@ class PersistentDrawer extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "persistent-drawer";
+    this._open = this._open.bind(this);
+    this._close = this._close.bind(this);
+  }
+  _open() {
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  }
+  _close() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   }
   componentDidMount() {
     this.MDComponent = MDCPersistentDrawer.attachTo(this.control);
-    this.MDComponent.listen("MDCPersistentDrawer:open", () => {
-      if (this.props.onOpen) {
-        this.props.onOpen();
-      }
-    });
-
-    this.MDComponent.listen("MDCPersistentDrawer:close", () => {
-      if (this.props.onClose) {
-        this.props.onClose();
-      }
-    });
+    this.MDComponent.listen("MDCPersistentDrawer:open", this._open);
+    this.MDComponent.listen("MDCPersistentDrawer:close", this._close);
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCPersistentDrawer:close", this._close);
+    this.MDComponent.unlisten("MDCPersistentDrawer:open", this._open);
   }
   materialDom(props) {
     return h(

--- a/Menu/Menu.jsx
+++ b/Menu/Menu.jsx
@@ -21,6 +21,9 @@ class Menu extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCSimpleMenu(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return (
       <div tabindex="-1" {...props} ref={control => (this.control = control)}>

--- a/Menu/Menu.jsx
+++ b/Menu/Menu.jsx
@@ -22,7 +22,7 @@ class Menu extends MaterialComponent {
     this.MDComponent = new MDCSimpleMenu(this.control);
   }
   componentWillUnmount() {
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(props) {
     return (

--- a/Menu/index.js
+++ b/Menu/index.js
@@ -35,6 +35,9 @@ class Menu extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCSimpleMenu(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return h(
       "div",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Smaller bundles FTW!!!
 
 - 👍 list
 
-- 👎🏽 menu
+- 👍 menu
 
 - 👍 radio
 

--- a/Radio/Radio.jsx
+++ b/Radio/Radio.jsx
@@ -14,6 +14,9 @@ export default class Radio extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = MDCRadio.attachTo(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy && this.MDComponent.destroy();
+  }
   materialDom(allprops) {
     const { className, ...props } = allprops;
     return (

--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -23,7 +23,7 @@ class Select extends MaterialComponent {
   }
   componentWillUnmount() {
     this.MDComponent.unlisten("MDCSelect:change", this._changed);
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   updateSelection(prevProps) {
     if (

--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -7,17 +7,23 @@ class Select extends MaterialComponent {
     super();
     this.componentName = "select";
     this._mdcProps = ["disabled"];
+    this._changed = this._changed.bind(this);
+  }
+  _changed() {
+    if (this.props.onChange) {
+      this.props.onChange();
+    }
   }
   componentDidMount() {
     if (!this.props.basic) {
       this.MDComponent = new MDCSelect(this.control);
-      this.MDComponent.listen("MDCSelect:change", () => {
-        if (this.props.onChange) {
-          this.props.onChange();
-        }
-      });
+      this.MDComponent.listen("MDCSelect:change", this._changed);
       this.updateSelection();
     }
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCSelect:change", this._changed);
+    this.MDComponent.destroy();
   }
   updateSelection(prevProps) {
     if (

--- a/Select/index.js
+++ b/Select/index.js
@@ -21,17 +21,23 @@ class Select extends MaterialComponent {
     super();
     this.componentName = "select";
     this._mdcProps = ["disabled"];
+    this._changed = this._changed.bind(this);
+  }
+  _changed() {
+    if (this.props.onChange) {
+      this.props.onChange();
+    }
   }
   componentDidMount() {
     if (!this.props.basic) {
       this.MDComponent = new MDCSelect(this.control);
-      this.MDComponent.listen("MDCSelect:change", () => {
-        if (this.props.onChange) {
-          this.props.onChange();
-        }
-      });
+      this.MDComponent.listen("MDCSelect:change", this._changed);
       this.updateSelection();
     }
+  }
+  componentWillUnmount() {
+    this.MDComponent.unlisten("MDCSelect:change", this._changed);
+    this.MDComponent.destroy();
   }
   updateSelection(prevProps) {
     if (

--- a/Snackbar/Snackbar.jsx
+++ b/Snackbar/Snackbar.jsx
@@ -13,7 +13,9 @@ export default class Snackbar extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = MDCSnackbar.attachTo(this.control);
   }
-
+  componentWillUnmount() {
+    this.MDComponent.destroy && this.MDComponent.destroy();
+  }
   materialDom(props) {
     return (
       <div

--- a/Tabs/Tabs.jsx
+++ b/Tabs/Tabs.jsx
@@ -16,6 +16,9 @@ class Tabs extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCTabBar(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return (
       <nav role="tablist" {...props} ref={control => (this.control = control)}>

--- a/Tabs/Tabs.jsx
+++ b/Tabs/Tabs.jsx
@@ -17,7 +17,7 @@ class Tabs extends MaterialComponent {
     this.MDComponent = new MDCTabBar(this.control);
   }
   componentWillUnmount() {
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(props) {
     return (

--- a/Tabs/index.js
+++ b/Tabs/index.js
@@ -30,6 +30,9 @@ class Tabs extends MaterialComponent {
   componentDidMount() {
     this.MDComponent = new MDCTabBar(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(props) {
     return h(
       "nav",

--- a/Textfield/Textfield.jsx
+++ b/Textfield/Textfield.jsx
@@ -22,13 +22,20 @@ export default class Textfield extends MaterialComponent {
     });
     this.MDComponent = new MDCTextfield(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(allprops) {
     const { className, ...props } = allprops;
     return (
       <div className={className + ""} ref={control => (this.control = control)}>
         {props.multiline
           ? <textarea className="mdc-textfield__input" {...props} />
-          : <input type={props.type || 'text'} className="mdc-textfield__input" {...props} />}
+          : <input
+              type={props.type || "text"}
+              className="mdc-textfield__input"
+              {...props}
+            />}
         {props.label &&
           this.state.showFloatingLabel &&
           <label className="mdc-textfield__label">

--- a/Textfield/Textfield.jsx
+++ b/Textfield/Textfield.jsx
@@ -23,7 +23,7 @@ export default class Textfield extends MaterialComponent {
     this.MDComponent = new MDCTextfield(this.control);
   }
   componentWillUnmount() {
-    this.MDComponent.destroy();
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   materialDom(allprops) {
     const { className, ...props } = allprops;

--- a/Textfield/index.js
+++ b/Textfield/index.js
@@ -46,6 +46,9 @@ export default class Textfield extends MaterialComponent {
     });
     this.MDComponent = new MDCTextfield(this.control);
   }
+  componentWillUnmount() {
+    this.MDComponent.destroy();
+  }
   materialDom(allprops) {
     const { className } = allprops,
       props = _objectWithoutProperties(allprops, ["className"]);
@@ -57,7 +60,10 @@ export default class Textfield extends MaterialComponent {
         : h(
             "input",
             _extends(
-              { type: props.type || "text", className: "mdc-textfield__input" },
+              {
+                type: props.type || "text",
+                className: "mdc-textfield__input"
+              },
               props
             )
           ),


### PR DESCRIPTION
As seen in #129, here is the PR.
Just destroying the underlying ```MDComponent``` in ```componentWillUnmount``` was not enough. I had to remove event handlers as well in ```Select```and ```Drawer``` components.
Thanks.