### PR TITLE
Remove className cast to string

### DIFF
--- a/Radio/Radio.jsx
+++ b/Radio/Radio.jsx
@@ -21,7 +21,7 @@ export default class Radio extends MaterialComponent {
     const { className, ...props } = allprops;
     return (
       <div
-        className={className + ""}
+        className={className}
         ref={control => {
           this.control = control;
         }}

--- a/Switch/Switch.jsx
+++ b/Switch/Switch.jsx
@@ -13,7 +13,7 @@ export default class Switch extends MaterialComponent {
   materialDom(allprops) {
     const { className, ...props } = allprops;
     return (
-      <div className={className + ""}>
+      <div className={className}>
         <input
           type="checkbox"
           className="mdc-switch__native-control"

--- a/Textfield/Textfield.jsx
+++ b/Textfield/Textfield.jsx
@@ -32,7 +32,7 @@ export default class Textfield extends MaterialComponent {
       labelClass.push("mdc-textfield__label--float-above");
     }
     return (
-      <div className={className + ""} ref={control => (this.control = control)}>
+      <div className={className} ref={control => (this.control = control)}>
         {props.multiline
           ? <textarea className="mdc-textfield__input" {...props} />
           : <input


### PR DESCRIPTION
Removes the ```className``` cast to string in Radio, Switch and Textfield components. Now an "undefined" class is not added to elements when no ```className``` is specified. This fixes #147.