### PR TITLE
Add Card.MediaItem

### DIFF
--- a/Card/Card.jsx
+++ b/Card/Card.jsx
@@ -1,6 +1,7 @@
 import { h } from "preact";
 import MaterialComponent from "../MaterialComponent";
 import Button from "../Button";
+
 class Card extends MaterialComponent {
   constructor() {
     super();
@@ -108,6 +109,21 @@ class CardHorizontalBlock extends CardSection {
   }
 }
 
+class CardMediaItem extends MaterialComponent {
+  constructor() {
+    super();
+    this.componentName = "card__media-item";
+    this._mdcProps = [];
+  }
+  materialDom(props) {
+    let className = "";
+    if (props.x) {
+      className = "mdc-card__media-item--" + props.x + "x";
+    }
+    return <img className={className} {...props} />;
+  }
+}
+
 Card.Primary = CardPrimary;
 Card.SupportingText = CardSupportingText;
 Card.Actions = CardActions;
@@ -116,5 +132,6 @@ Card.Media = CardMedia;
 Card.Title = CardTitle;
 Card.Subtitle = CardSubtitle;
 Card.HorizontalBlock = CardHorizontalBlock;
+Card.MediaItem = CardMediaItem;
 
 export default Card;


### PR DESCRIPTION
This works somewhat like the ```Elevation``` components. We can set the ```x``` prop to ```1dot5```, ```2``` or ```3```.
Those are not in ```_mdcProps``` because unless I'm missing something we can't use props starting with an integer.

Not quite sure if I should call the prop ```x``` or ```size```, and maybe we could add something like ```String(props.x).replace('.', 'dot')``` to allow using ```x="1.5"``` instead of ```x="1dot5"```, but that seems kind of overkill.

Fixes #182.