### PR TITLE
Add menu prop to Toolbar

### DIFF
--- a/Toolbar/Toolbar.jsx
+++ b/Toolbar/Toolbar.jsx
@@ -65,6 +65,7 @@ class ToolbarIcon extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "toolbar__icon";
+    this._mdcProps = ["menu"];
   }
   materialDom(props) {
     return (

--- a/Toolbar/Toolbar.jsx
+++ b/Toolbar/Toolbar.jsx
@@ -62,10 +62,10 @@ class ToolbarSection extends MaterialComponent {
 }
 
 class ToolbarIcon extends MaterialComponent {
-  constructor() {
+  constructor(props) {
     super();
     this.componentName = "toolbar__icon";
-    if (this.props.menu) {
+    if (props.menu) {
       this.componentName += "--menu";
     }
   }

--- a/Toolbar/Toolbar.jsx
+++ b/Toolbar/Toolbar.jsx
@@ -61,6 +61,9 @@ class ToolbarSection extends MaterialComponent {
   }
 }
 
+/**
+ * @prop menu = false
+ */
 class ToolbarIcon extends MaterialComponent {
   constructor(props) {
     super();

--- a/Toolbar/Toolbar.jsx
+++ b/Toolbar/Toolbar.jsx
@@ -65,7 +65,9 @@ class ToolbarIcon extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "toolbar__icon";
-    this._mdcProps = ["menu"];
+    if (this.props.menu) {
+      this.componentName += "--menu";
+    }
   }
   materialDom(props) {
     return (


### PR DESCRIPTION
From the [MDC Toolbar docs](https://material.io/components/web/catalog/toolbar):
> There are two types of icons, `mdc-toolbar__icon--menu` represents the left most icon in `mdc-toolbar` usually to the left of `mdc-toolbar__title`

This will allow fixing the left/right padding on toolbar icons. I'm working on updating the demo/docs site. (AFAIK a release has to be made before I can compile the docs site?)