### PR TITLE
Fix Select throwing error on componentWillUnmount if using 'basic'

### DIFF
--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -25,8 +25,10 @@ class Select extends MaterialComponent {
     }
   }
   componentWillUnmount() {
-    this.MDComponent.unlisten("MDCSelect:change", this._changed);
-    this.MDComponent.destroy && this.MDComponent.destroy();
+    if (!this.props.basic) {
+      this.MDComponent.unlisten("MDCSelect:change", this._changed);
+      this.MDComponent.destroy && this.MDComponent.destroy();
+    }
   }
   updateSelection() {
     if ("selectedIndex" in this.props && this.MDComponent) {


### PR DESCRIPTION
When using `<Select basic={true} />` it throws an error:
```
TypeError: Cannot read property 'unlisten' of undefined
    at Select_Select.componentWillUnmount
```