### PR TITLE
Fix applying CSS on components with user-defined className

### DIFF
--- a/MaterialComponent.js
+++ b/MaterialComponent.js
@@ -59,6 +59,7 @@ export default class MaterialComponent extends Component {
     const element = this.materialDom(this.props);
     element.attributes = element.attributes || {};
     // Fix for className
+    element.attributes.class = this.getClassName(element);
     element.attributes.className = this.getClassName(element);
     // Clean this shit of proxy attributes
     this._mdcProps.forEach(prop => {


### PR DESCRIPTION
From [comment](https://github.com/prateekbh/preact-material-components/pull/217#issuecomment-325885255) on #217:

It changed it so the classes were applied to className, but when there is already a className on the component, the material classes weren't added.

For example, `<Toolbar className="mdc-theme--dark">` only has `mdc-theme--dark` class in the rendered HTML instead of `mdc-theme--dark mdc-toolbar`.

I think this is because Preact [duplicates the class and className attributes](https://github.com/developit/preact/blob/33fc697ac11762a1cb6e71e9847670d047af7ce5/src/dom/index.js#L36). When I re-add the original line it fixes the problem.