### PR TITLE
[WIP] Add TextfieldInput ref to Textfield and fix focused state

### DIFF
--- a/MaterialComponent.js
+++ b/MaterialComponent.js
@@ -56,7 +56,7 @@ export default class MaterialComponent extends Component {
   render() {
     this.buildClassName();
     // Fetch a VNode
-    const element = this.materialDom(this.props);
+    const element = this.materialDom(this.props, this.state);
     element.attributes = element.attributes || {};
     // Fix for className
     element.attributes.class = this.getClassName(element);

--- a/Textfield/Textfield.jsx
+++ b/Textfield/Textfield.jsx
@@ -87,10 +87,16 @@ class TextfieldInput extends MaterialComponent {
 
   materialDom(allprops, { showFloatingLabel, isFocused }) {
     let { className, ...props } = allprops;
+    let labelClassName = "mdc-textfield__label";
+
     const upgrade = props.value || isFocused;
 
-    if (showFloatingLabel && upgrade) {
+    if (showFloatingLabel) {
       className = [className, "mdc-textfield--upgraded"].join(" ");
+    }
+
+    if (upgrade) {
+      labelClassName = [labelClassName, "mdc-textfield__label--float-above"].join(" ");
     }
 
     return (
@@ -113,7 +119,7 @@ class TextfieldInput extends MaterialComponent {
           this.state.showFloatingLabel &&
           <Label
             for={props.id}
-            className={upgrade && "mdc-textfield__label--float-above"}
+            className={labelClassName}
           >
             {props.label}
           </Label>}

--- a/Textfield/Textfield.jsx
+++ b/Textfield/Textfield.jsx
@@ -51,9 +51,13 @@ class TextfieldInput extends MaterialComponent {
     this.componentName = "textfield";
     this._mdcProps = ["fullwidth", "multiline", "dense", "disabled", "box"];
     this.state = {
-      showFloatingLabel: false
+      showFloatingLabel: false,
+      isFocused: false
     };
+    this._onFocus = this._onFocus.bind(this);
+    this._onBlur = this._onBlur.bind(this);
   }
+
   componentDidMount() {
     this.setState(
       {
@@ -64,13 +68,28 @@ class TextfieldInput extends MaterialComponent {
       }
     );
   }
+
   componentWillUnmount() {
     this.MDComponent && this.MDComponent.destroy && this.MDComponent.destroy();
   }
-  materialDom(allprops) {
-    let { className, ...props } = allprops;
+  
+  _onFocus() {
+    this.setState({
+      isFocused: true
+    });
+  }
 
-    if (props.value && this.state.showFloatingLabel) {
+  _onBlur() {
+    this.setState({
+      isFocused: false
+    });
+  }
+
+  materialDom(allprops, { showFloatingLabel, isFocused }) {
+    let { className, ...props } = allprops;
+    const upgrade = props.value || isFocused;
+
+    if (showFloatingLabel && upgrade) {
       className = [className, "mdc-textfield--upgraded"].join(" ");
     }
 
@@ -79,18 +98,22 @@ class TextfieldInput extends MaterialComponent {
         {props.multiline
           ? <textarea
               className="mdc-textfield__input"
+              onFocus={this._onFocus}
+              onBlur={this._onBlur}
               {...props}
             />
           : <input
               type={props.type || "text"}
               className="mdc-textfield__input"
+              onFocus={this._onFocus}
+              onBlur={this._onBlur}
               {...props}
             />}
         {props.label &&
           this.state.showFloatingLabel &&
           <Label
             for={props.id}
-            className={props.value && "mdc-textfield__label--float-above"}
+            className={upgrade && "mdc-textfield__label--float-above"}
           >
             {props.label}
           </Label>}
@@ -134,6 +157,13 @@ class Textfield extends Component {
     return ++this.uidCounter;
   }
 
+  _setInputRef(ref) {
+    if (ref) {
+      this.input = ref;
+      this.MDComponent = ref.MDComponent;
+    }
+  }
+
   render(allprops, { showFloatingLabel }) {
     const {
       className,
@@ -146,6 +176,8 @@ class Textfield extends Component {
     if (showDiv && !props.id) {
       props.id = "tf-" + this.id;
     }
+
+    props.ref = this._setInputRef;
 
     // Helper text
     const helptextProps = {


### PR DESCRIPTION
Closes #236.

- Adds ```input``` as a reference to the underlying ```TextfieldInput``` of a ```Textfield```. Makes it possible to access ```MDComponent```: ```textfieldRef.input.MDComponent```.
- Keeps floating label when input is focused but value is falsy.

To do:
- Test if this doesn't break anything
- Keep ```mdc-textfield--upgraded``` on JS-enabled clients because labels currently don't work correctly after the first focus.