### PR TITLE
Only deploy for NodeJS 8 and docs environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ before_deploy: cd $TRAVIS_BUILD_DIR/docs && npm run build
 
 deploy:
   provider: pages
-  local_dir: docs/build
+  local_dir: $TRAVIS_BUILD_DIR/docs/build
   target_branch: gh-pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:
     branch: master
-    condition: $(./scripts/has-changes.sh docs) = "yes"
+    condition: $(./scripts/has-changes.sh docs) = "yes" && $TEST_DIR = "docs"
+    node: "8"
 
 # blocklist
 branches:


### PR DESCRIPTION
Changes three things:
- Make sure to deploy the right folder (hopefully environment variables are supported there, documentation is not quite clear on that)
- Only deploy for NodeJS 8
- Only deploy when we are actually testing docs and not the root repo