### PR TITLE
Support custom `class` prop

### DIFF
--- a/MaterialComponent.js
+++ b/MaterialComponent.js
@@ -43,11 +43,15 @@ export default class MaterialComponent extends Component {
     if (!element) {
       return "";
     }
-    element.attributes = element.attributes || {};
-    if (element.attributes.className) {
-      return this.classText + " " + element.attributes.className;
+    const attrs = element.attributes = element.attributes || {};
+    let classText = this.classText;
+    if (attrs.class) {
+      classText += " " + attrs.class;
     }
-    return this.classText;
+    if (attrs.className && attrs.className!==attrs.class) {
+      classText += " " + attrs.className;
+    }
+    return classText;
   }
   // Components must implement this method for their specific DOM structure
   materialDom(props) {


### PR DESCRIPTION
Example: `<Card.Title class="foo" />`
Currently only `className` is supported.