### PR TITLE
Textfield icons

### DIFF
--- a/TextField/TextField.jsx
+++ b/TextField/TextField.jsx
@@ -75,19 +75,15 @@ class TextFieldInput extends MaterialComponent {
   }
   materialDom(allprops) {
     let { className, ...props } = allprops;
+    className = className || "";
 
-    props.leadingIcon
-      ? className != null
-        ? (className +=
-            " mdc-text-field--box mdc-text-field--with-leading-icon")
-        : (className = "mdc-text-field--box mdc-text-field--with-leading-icon")
-      : null;
-    props.trailingIcon
-      ? className != null
-        ? (className +=
-            " mdc-text-field--box mdc-text-field--with-trailing-icon")
-        : (className = "mdc-text-field--box mdc-text-field--with-trailing-icon")
-      : null;
+    if ("leadingIcon" in props) {
+      className += " mdc-text-field--box mdc-text-field--with-leading-icon";
+    }
+
+    if ("trailingIcon" in props) {
+      className += " mdc-text-field--box mdc-text-field--with-trailing-icon";
+    }
 
     if ("value" in props && this.state.showFloatingLabel) {
       className = [className, "mdc-text-field--upgraded"].join(" ");

--- a/TextField/TextField.jsx
+++ b/TextField/TextField.jsx
@@ -1,6 +1,7 @@
 import { h, Component } from "preact";
 import MaterialComponent from "../MaterialComponent";
 import { MDCTextField } from "@material/textfield";
+import Icon from "../Icon";
 
 /**
  * @prop persistent = false
@@ -100,9 +101,7 @@ class TextFieldInput extends MaterialComponent {
     return (
       <div className={className} ref={control => (this.control = control)}>
         {props.leadingIcon ? (
-          <i className="material-icons mdc-text-field__icon">
-            {props.leadingIcon}
-          </i>
+          <Icon className="mdc-text-field__icon">{props.leadingIcon}</Icon>
         ) : null}
         {props.textarea ? (
           <textarea className="mdc-text-field__input" {...props} />
@@ -118,9 +117,7 @@ class TextFieldInput extends MaterialComponent {
             <Label for={props.id}>{props.label}</Label>
           )}
         {props.trailingIcon ? (
-          <i className="material-icons mdc-text-field__icon">
-            {props.trailingIcon}
-          </i>
+          <Icon className="mdc-text-field__icon">{props.trailingIcon}</Icon>
         ) : null}
         {props.textarea ? "" : <div class="mdc-text-field__bottom-line" />}
       </div>

--- a/TextField/TextField.jsx
+++ b/TextField/TextField.jsx
@@ -75,6 +75,19 @@ class TextFieldInput extends MaterialComponent {
   materialDom(allprops) {
     let { className, ...props } = allprops;
 
+    props.leadingIcon
+      ? className != null
+        ? (className +=
+            " mdc-text-field--box mdc-text-field--with-leading-icon")
+        : (className = "mdc-text-field--box mdc-text-field--with-leading-icon")
+      : null;
+    props.trailingIcon
+      ? className != null
+        ? (className +=
+            " mdc-text-field--box mdc-text-field--with-trailing-icon")
+        : (className = "mdc-text-field--box mdc-text-field--with-trailing-icon")
+      : null;
+
     if ("value" in props && this.state.showFloatingLabel) {
       className = [className, "mdc-text-field--upgraded"].join(" ");
     }
@@ -86,6 +99,11 @@ class TextFieldInput extends MaterialComponent {
 
     return (
       <div className={className} ref={control => (this.control = control)}>
+        {props.leadingIcon ? (
+          <i className="material-icons mdc-text-field__icon">
+            {props.leadingIcon}
+          </i>
+        ) : null}
         {props.textarea ? (
           <textarea className="mdc-text-field__input" {...props} />
         ) : (
@@ -99,6 +117,11 @@ class TextFieldInput extends MaterialComponent {
           this.state.showFloatingLabel && (
             <Label for={props.id}>{props.label}</Label>
           )}
+        {props.trailingIcon ? (
+          <i className="material-icons mdc-text-field__icon">
+            {props.trailingIcon}
+          </i>
+        ) : null}
         {props.textarea ? "" : <div class="mdc-text-field__bottom-line" />}
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -90,8 +90,14 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "lint-staged": {
-    "index.js": ["prettier --write", "git add"],
-    "**/*.jsx": ["prettier --write", "git add"]
+    "index.js": [
+      "prettier --write",
+      "git add"
+    ],
+    "**/*.jsx": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "pre-commit": "lint-staged"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-material-components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "preact wrapper for \"Material Components for the web\"",
   "module": "index.js",
   "main": "dist/index.js",
@@ -90,14 +90,8 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "lint-staged": {
-    "index.js": [
-      "prettier --write",
-      "git add"
-    ],
-    "**/*.jsx": [
-      "prettier --write",
-      "git add"
-    ]
+    "index.js": ["prettier --write", "git add"],
+    "**/*.jsx": ["prettier --write", "git add"]
   },
   "pre-commit": "lint-staged"
 }

--- a/sample/home.jsx
+++ b/sample/home.jsx
@@ -200,6 +200,14 @@ export default class Home extends Component {
         </div>
 
         <div>
+          <TextField label="plain" leadingIcon="check" />
+        </div>
+
+        <div>
+          <TextField label="plain" />
+        </div>
+
+        <div>
           <TextField label="textarea" textarea />
         </div>
 

--- a/sample/home.jsx
+++ b/sample/home.jsx
@@ -200,7 +200,11 @@ export default class Home extends Component {
         </div>
 
         <div>
-          <TextField label="plain" leadingIcon="check" />
+          <TextField label="trailing" trailingIcon="check" />
+        </div>
+
+        <div>
+          <TextField label="leading" leadingIcon="check" />
         </div>
 
         <div>


### PR DESCRIPTION
Implemented both trailing & leading icons in textfields. Use `trailingIcon` or `leadingIcon` prop, passing the name of the material icon