### PR TITLE
Select - fix "unselected" state

### DIFF
--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -43,7 +43,10 @@ class Select extends MaterialComponent {
     this.updateSelection();
     if (this.MDComponent && this.MDComponent.foundation_) {
       this.MDComponent.foundation_.resize();
-      if (this.props.selectedIndex == null || this.props.selectedIndex == -1) {
+      if (
+        this.props.selectedIndex === null ||
+        this.props.selectedIndex === -1
+      ) {
         this.MDComponent.foundation_.adapter_.setSelectedTextContent(
           this.props.hintText
         );

--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -43,6 +43,11 @@ class Select extends MaterialComponent {
     this.updateSelection();
     if (this.MDComponent && this.MDComponent.foundation_) {
       this.MDComponent.foundation_.resize();
+      if (this.props.selectedIndex == null || this.props.selectedIndex == -1) {
+        this.MDComponent.foundation_.adapter_.setSelectedTextContent(
+          this.props.hintText
+        );
+      }
     }
   }
   materialDom(props) {

--- a/docs/src/routes/select/index.js
+++ b/docs/src/routes/select/index.js
@@ -32,7 +32,7 @@ export default class SelectPage extends Component {
             name: "hintText",
             value: "string",
             description:
-              'Helpful text to display when no selection has been made. ("selectedIndex" must be "null" for the hintText to show)'
+              'Helpful text to display when no selection has been made. ("selectedIndex" must be -1 for the hintText to show)'
           },
           {
             name: "onChange",
@@ -67,9 +67,8 @@ export default class SelectPage extends Component {
 
         <div className="mdc-typography--display1">Original documentation</div>
         <div className="mdc-typography--body">
-          This component encapsulates <span className="strong">
-            mdc-select
-          </span>, you can refer to its documentation
+          This component encapsulates <span className="strong">mdc-select</span>,
+          you can refer to its documentation
           <a href="https://github.com/material-components/material-components-web/tree/master/packages/mdc-select">
             {" "}
             here

--- a/docs/src/routes/select/index.js
+++ b/docs/src/routes/select/index.js
@@ -67,8 +67,9 @@ export default class SelectPage extends Component {
 
         <div className="mdc-typography--display1">Original documentation</div>
         <div className="mdc-typography--body">
-          This component encapsulates <span className="strong">mdc-select</span>,
-          you can refer to its documentation
+          This component encapsulates <span className="strong">
+            mdc-select
+          </span>, you can refer to its documentation
           <a href="https://github.com/material-components/material-components-web/tree/master/packages/mdc-select">
             {" "}
             here

--- a/sample/home.jsx
+++ b/sample/home.jsx
@@ -276,23 +276,29 @@ export default class Home extends Component {
         </Button>
         <LinearProgress progress={this.state.progress} accent={true} />
 
-        <Select
-          hintText="Select an option"
-          ref={presel => {
-            this.presel = presel;
-          }}
-          selectedIndex={this.state.chosenOption}
-          onChange={e => {
-            this.setState({
-              chosenOption: e.selectedIndex
-            });
-          }}
-        >
-          <Select.Item>opt1</Select.Item>
-          <Select.Item>opt2</Select.Item>
-          <Select.Item>opt3</Select.Item>
-          <Select.Item>opt4</Select.Item>
-        </Select>
+        <Button raised onClick={() => this.setState({ chosenOption: -1 })}>
+          Clear Select
+        </Button>
+        <div>
+          <Select
+            hintText="Select an option"
+            ref={presel => {
+              this.presel = presel;
+            }}
+            selectedIndex={this.state.chosenOption}
+            onChange={e => {
+              this.setState({
+                chosenOption: e.selectedIndex
+              });
+            }}
+          >
+            <Select.Item>opt1</Select.Item>
+            <Select.Item>opt2</Select.Item>
+            <Select.Item>opt3</Select.Item>
+            <Select.Item>opt4</Select.Item>
+          </Select>
+        </div>
+
         <div>
           <Tabs indicator-accent={true}>
             <Tabs.Tab>tab1</Tabs.Tab>


### PR DESCRIPTION
This addresses an issue where passing -1 as `selectedIndex` would cause `hintText` to be hidden. The preferred method to _clear_ a selection is now to pass `selectedIndex={1}` instead of `selectedIndex={null}`. 

`selectedIndex={null}` leaves `aria-selected=true`