### PR TITLE
fix(docs): fix spelling in the description of the button component.

### DIFF
--- a/docs/src/routes/button/index.js
+++ b/docs/src/routes/button/index.js
@@ -186,7 +186,7 @@ export default class ButtonPage extends Component {
         <div className="mdc-typography--caption">
           <div>
             Adding an <code>href</code> to the <code>Button</code> automatically
-            makes in an <code>&lt;a&gt;</code>.
+            makes it an <code>&lt;a&gt;</code>.
           </div>
         </div>
       </div>


### PR DESCRIPTION
I noticed while looking shortly through the docs that there was a typo with `in` and `it`.