### PR TITLE
Typescript declaration improvements

### DIFF
--- a/Checkbox/index.d.ts
+++ b/Checkbox/index.d.ts
@@ -3,7 +3,7 @@ import { VNode } from 'preact';
 import { MDCFoundation, MDCComponent, MDCRipple } from '../MaterialComponentsWeb';
 
 declare interface ICheckboxProps extends JSX.HTMLAttributes {
-  disabled?: boolean;
+  indeterminate?: boolean;
 }
 export default class Checkbox extends MaterialComponent<ICheckboxProps, {}> {
   MDComponent: MDCCheckbox;

--- a/Dialog/index.d.ts
+++ b/Dialog/index.d.ts
@@ -5,8 +5,8 @@ import { MDCFoundation, MDCComponent } from '../MaterialComponentsWeb';
 import { Omit } from '../libs';
 
 declare interface IDialogProps extends JSX.HTMLAttributes {
-  onAccept?: () => void;
-  onCancel?: () => void;
+  onAccept?: (e: Event) => void;
+  onCancel?: (e: Event) => void;
 }
 export default class Dialog extends MaterialComponent<IDialogProps, {}> {
   static Header: typeof Header;

--- a/GridList/GridList.jsx
+++ b/GridList/GridList.jsx
@@ -9,7 +9,7 @@ const notEmptyString = val => val !== "";
  * @prop header-caption {boolean} - position <GridList.SecondaryTile> at top
  * @prop twoline-caption {boolean} - add spacing to <GridList.SecondaryTile> for <GridList.SupportTextTile>
  * @prop with-icon-align {"start"|"end"} - position <GridList.IconTile> at beginning or end of <GridList.SecondaryTile>
- * @prop aspect-ratio {"1x1"|"16x9"|"2x3"|"3x2"|"4x3"|"3x4"} - aspect ratio for <GridList.PrimaryTile>
+ * @prop tile-aspect {"1x1"|"16x9"|"2x3"|"3x2"|"4x3"|"3x4"} - aspect ratio for <GridList.PrimaryTile>
  */
 class GridList extends MaterialComponent {
   get validationValuesByKey() {

--- a/GridList/index.d.ts
+++ b/GridList/index.d.ts
@@ -5,8 +5,8 @@ declare interface IGridListProps extends JSX.HTMLAttributes {
   'tile-gutter-1'?: boolean;
   'header-caption'?: boolean;
   'twoline-caption'?: boolean;
-  'with-icon-align': "start"|"end";
-  'aspect-ratio': "1x1"|"16x9"|"2x3"|"3x2"|"4x3"|"3x4";
+  'with-icon-align'?: "start"|"end";
+  'tile-aspect'?: "1x1"|"16x9"|"2x3"|"3x2"|"4x3"|"3x4";
 }
 export default class GridList extends MaterialComponent<IGridListProps, {}> {
   static Tiles: typeof Tiles;

--- a/Icon/index.d.ts
+++ b/Icon/index.d.ts
@@ -1,5 +1,4 @@
 import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 
-declare interface IIconProps extends JSX.HTMLAttributes {}
-export default class Icon extends MaterialComponent<IIconProps, {}> {}
+export default class Icon extends MaterialComponent<JSX.HTMLAttributes, {}> {}

--- a/Icon/index.d.ts
+++ b/Icon/index.d.ts
@@ -1,7 +1,5 @@
 import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 
-declare interface IIconProps extends JSX.HTMLAttributes {
-  disabled?: boolean;
-}
+declare interface IIconProps extends JSX.HTMLAttributes {}
 export default class Icon extends MaterialComponent<IIconProps, {}> {}

--- a/IconToggle/index.d.ts
+++ b/IconToggle/index.d.ts
@@ -2,10 +2,15 @@ import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 import { MDCFoundation, MDCComponent, MDCRipple } from '../MaterialComponentsWeb';
 
+declare interface IconToggleState {
+  label?: string;
+  content?: string;
+  cssClass?: string;
+}
+
 declare interface IIconToggleProps extends JSX.HTMLAttributes {
-  disabled?: boolean;
-  'data-toggle-on'?: any;
-  'data-toggle-off'?: any;
+  'data-toggle-on'?: IconToggleState;
+  'data-toggle-off'?: IconToggleState;
 }
 export default class IconToggle extends MaterialComponent<IIconToggleProps, {}> {
   MDComponent: MDCIconToggle;

--- a/IconToggle/index.d.ts
+++ b/IconToggle/index.d.ts
@@ -2,15 +2,15 @@ import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 import { MDCFoundation, MDCComponent, MDCRipple } from '../MaterialComponentsWeb';
 
-declare interface IconToggleState {
+type IconToggleData = {
   label?: string;
   content?: string;
   cssClass?: string;
 }
 
 declare interface IIconToggleProps extends JSX.HTMLAttributes {
-  'data-toggle-on'?: IconToggleState;
-  'data-toggle-off'?: IconToggleState;
+  'data-toggle-on'?: IconToggleData;
+  'data-toggle-off'?: IconToggleData;
 }
 export default class IconToggle extends MaterialComponent<IIconToggleProps, {}> {
   MDComponent: MDCIconToggle;

--- a/LayoutGrid/index.d.ts
+++ b/LayoutGrid/index.d.ts
@@ -8,12 +8,16 @@ export default class LayoutGrid extends MaterialComponent<JSX.HTMLAttributes, {}
 
 declare class LayoutGridInner extends MaterialComponent<JSX.HTMLAttributes, {}> {}
 
+type PhoneCols = 1 | 2 | 3 | 4;
+type TabletCols = PhoneCols | 5 | 6 | 7 | 8;
+type LayoutCols = TabletCols | 9 | 10 | 11 | 12;
+
 declare interface ILayoutGridCellProps extends JSX.HTMLAttributes {
-  cols?: number;
-  desktopCols?: number;
-  tabletCols?: number;
-  phoneCols?: number;
-  order?: number;
-  align?: string;
+  cols?: LayoutCols;
+  desktopCols?: LayoutCols;
+  tabletCols?: TabletCols;
+  phoneCols?: PhoneCols;
+  order?: LayoutCols;
+  align?: 'top' | 'middle' | 'bottom';
 }
 declare class LayoutGridCell extends MaterialComponent<ILayoutGridCellProps, {}> {}

--- a/LinearProgress/LinearProgress.jsx
+++ b/LinearProgress/LinearProgress.jsx
@@ -5,7 +5,6 @@ import { MDCLinearProgress } from "@material/linear-progress";
 /**
  * @prop indeterminate = false
  * @prop reversed = false
- * @prop accent = false
  */
 export default class LinearProgress extends MaterialComponent {
   constructor() {

--- a/LinearProgress/index.d.ts
+++ b/LinearProgress/index.d.ts
@@ -5,7 +5,7 @@ import { MDCFoundation, MDCComponent } from '../MaterialComponentsWeb';
 declare interface ILinearProgressProps extends JSX.HTMLAttributes {
   indeterminate?: boolean;
   reversed?: boolean;
-  accent?: boolean;
+  progress?: number;
 }
 export default class LinearProgress extends MaterialComponent<ILinearProgressProps, {}> {
   MDComponent: MDCLinearProgress;

--- a/List/index.d.ts
+++ b/List/index.d.ts
@@ -29,7 +29,11 @@ declare class ItemIcon extends MaterialComponent<IItemIconProps, {}> {
   getProxyClassName(props: IItemIconProps): string;
 }
 
-declare class ItemAvatar extends MaterialComponent<JSX.HTMLAttributes, {}> {}
+declare interface IItemAvatarProps extends JSX.HTMLAttributes {
+  'start-detail'?: boolean;
+  'end-detail'?: boolean;
+}
+declare class ItemAvatar extends MaterialComponent<IItemAvatarProps, {}> {}
 
 declare interface IDividerProps extends JSX.HTMLAttributes {
   inset?: boolean;

--- a/List/index.d.ts
+++ b/List/index.d.ts
@@ -29,11 +29,7 @@ declare class ItemIcon extends MaterialComponent<IItemIconProps, {}> {
   getProxyClassName(props: IItemIconProps): string;
 }
 
-declare interface IItemAvatarProps extends JSX.HTMLAttributes {
-  'start-detail'?: boolean;
-  'end-detail'?: boolean;
-}
-declare class ItemAvatar extends MaterialComponent<IItemAvatarProps, {}> {}
+declare class ItemAvatar extends ItemIcon {}
 
 declare interface IDividerProps extends JSX.HTMLAttributes {
   inset?: boolean;

--- a/Menu/index.d.ts
+++ b/Menu/index.d.ts
@@ -9,6 +9,9 @@ declare interface IMenuProps extends JSX.HTMLAttributes {
   'open-from-top-right'?: boolean;
   'open-from-bottom-left'?: boolean;
   'open-from-bottom-right'?: boolean;
+  onSelect?: () => void;
+  onCancel?: () => void;
+  onMenuClosed?: () => void;
 }
 
 export default class Menu extends MaterialComponent<IMenuProps, {}> {

--- a/Select/index.d.ts
+++ b/Select/index.d.ts
@@ -7,6 +7,7 @@ import { Omit } from '../libs';
 declare interface ISelectProps extends Omit<JSX.HTMLAttributes, 'onChange' | 'disabled'> {
   disabled?: boolean;
   basic?: boolean;
+  hintText?: string;
   selectedIndex?: number;
   onChange?: (e: { selectedIndex: number, selectedOptions: NodeListOf<Element> }) => void;
 }

--- a/Slider/index.d.ts
+++ b/Slider/index.d.ts
@@ -3,8 +3,7 @@ import { VNode } from 'preact';
 import { MDCFoundation, MDCComponent } from '../MaterialComponentsWeb';
 import { Omit } from '../libs';
 
-declare interface ISliderProps extends Omit<JSX.HTMLAttributes, 'value' | 'disabled' | 'min' | 'max' | 'step' | 'onInput' | 'onChange'> {
-  disabled?: boolean;
+declare interface ISliderProps extends Omit<JSX.HTMLAttributes, 'value' | 'min' | 'max' | 'step' | 'onInput' | 'onChange'> {
   discrete?: boolean;
   value?: number;
   min?: number;

--- a/Snackbar/index.d.ts
+++ b/Snackbar/index.d.ts
@@ -2,7 +2,11 @@ import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 import { MDCFoundation, MDCComponent } from '../MaterialComponentsWeb';
 
-export default class Snackbar extends MaterialComponent<JSX.HTMLAttributes, {}> {
+declare interface ISnackbarProps extends JSX.HTMLAttributes {
+  dismissesOnAction?: boolean;
+}
+
+export default class Snackbar extends MaterialComponent<ISnackbarProps, {}> {
   MDComponent: MDCSnackbar;
 }
 
@@ -11,8 +15,8 @@ declare interface ISnackbarData {
   multiline?: boolean;
   actionOnBottom?: boolean;
   timeout?: number;
-  actionHandler: Function;
-  actionText: string;
+  actionHandler?: Function;
+  actionText?: string;
 }
 
 declare class MDCSnackbarFoundation extends MDCFoundation<MDCSnackbar> {

--- a/Switch/index.d.ts
+++ b/Switch/index.d.ts
@@ -1,7 +1,4 @@
 import MaterialComponent from '../MaterialComponent';
 import { VNode } from 'preact';
 
-declare interface ISwitchProps extends JSX.HTMLAttributes {
-  disabled?: boolean;
-}
-export default class Switch extends MaterialComponent<ISwitchProps, {}> {}
+export default class Switch extends MaterialComponent<JSX.HTMLAttributes, {}> {}

--- a/TextField/index.d.ts
+++ b/TextField/index.d.ts
@@ -9,10 +9,16 @@ declare interface IHelperTextProps extends JSX.HTMLAttributes {
 declare class HelperText extends MaterialComponent<IHelperTextProps, {}> {}
 
 declare interface ITextFieldProps extends JSX.HTMLAttributes {
+  fullwidth?: boolean;
+  textarea?: boolean;
+  dense?: boolean;
+  box?: boolean;
   helperText?: string;
-  helperTextPersistent?: string;
-  helperTextValidationMsg?: string;
+  helperTextPersistent?: boolean;
+  helperTextValidationMsg?: boolean;
   cssLabel?: string;
+  leadingIcon?: string;
+  trailingIcon?: string;
 }
 declare interface ITextFieldState {
   showFloatingLabel: boolean;

--- a/docs/src/routes/elevation/index.js
+++ b/docs/src/routes/elevation/index.js
@@ -24,8 +24,8 @@ export default class ElevationPage extends Component {
         props: [
           {
             name: "z",
-            value: "1 to 25",
-            description: "Add z=(1 to 25) to get different elevations."
+            value: "0 to 24",
+            description: "Add z=(0 to 24) to get different elevations."
           }
         ]
       }

--- a/docs/src/routes/form-field/sample.txt
+++ b/docs/src/routes/form-field/sample.txt
@@ -1,16 +1,17 @@
 import {h, Component} from 'preact';
-import List from 'preact-material-components/List';
-import Formfield from 'preact-material-components/FormField';
-import 'preact-material-components/List/style.css';
+import Radio from 'preact-material-components/Radio';
+import FormField from 'preact-material-components/FormField';
+import 'preact-material-components/Radio/style.css';
+import 'preact-material-components/FormField/style.css';
 
-export default class ListPage extends Component {
+export default class FormFieldPage extends Component {
   render(){
     return (
       <div>
-        <Formfield>
+        <FormField>
           <Radio id="r1" name='opts'></Radio>
           <label for="r1">Radio 1</label>
-        </Formfield>
+        </FormField>
       </div>
     );
   }

--- a/docs/src/routes/icon-toggle/sample.txt
+++ b/docs/src/routes/icon-toggle/sample.txt
@@ -1,18 +1,17 @@
 import {h, Component} from 'preact';
-import List from 'preact-material-components/List';
-import Formfield from 'preact-material-components/FormField';
-import 'preact-material-components/List/style.css';
+import IconToggle from 'preact-material-components/IconToggle';
+import 'preact-material-components/IconToggle/style.css';
 
-export default class ListPage extends Component {
-  const toggleOnIcon = {
-    content: "favorite",
-    label: "Remove From Favorites"
-  };
-  const toggleOffIcon = {
-    content: "favorite_border",
-    label: "Add to Favorites"
-  };
+export default class IconTogglePage extends Component {
   render(){
+    const toggleOnIcon = {
+      content: "favorite",
+      label: "Remove From Favorites"
+    };
+    const toggleOffIcon = {
+      content: "favorite_border",
+      label: "Add to Favorites"
+    };
     return (
       <div>
         <IconToggle

--- a/docs/src/routes/select/sample.txt
+++ b/docs/src/routes/select/sample.txt
@@ -15,8 +15,8 @@ export default class SelectPage extends Component {
             this.setState({
               chosenIndex: e.selectedIndex
             });
-            //selected option
-            console.log(e.selectedOption);
+            //selected options
+            console.log(e.selectedOptions);
           }}>
             <Select.Item>opt1</Select.Item>
             <Select.Item>opt2</Select.Item>

--- a/docs/src/routes/textfield/index.js
+++ b/docs/src/routes/textfield/index.js
@@ -40,20 +40,26 @@ export default class TextFieldPage extends Component {
             description: "Use a dense font"
           },
           {
+            name: "box",
+            description:
+              "Enclose label and input in a transparent rectangular fill"
+          },
+          {
             name: "disabled",
             description: "Disables the input"
           },
           {
-            name: "helptext",
+            name: "helperText",
             description:
-              "Include an help text that is useful for providing supplemental information to users, as well for validation messages"
+              "Include an help text that is useful for providing supplemental information to users, as well for validation messages",
+            value: "help text"
           },
           {
-            name: "helptextPersistent",
+            name: "helperTextPersistent",
             description: "Makes the help text always visible"
           },
           {
-            name: "helptextValidationMsg",
+            name: "helperTextValidationMsg",
             description:
               "Provide styles for using the help text as a validation message"
           }

--- a/docs/src/routes/textfield/sample.txt
+++ b/docs/src/routes/textfield/sample.txt
@@ -1,12 +1,12 @@
 import {h, Component} from 'preact';
-import Textfield from 'preact-material-components/Textfield';
-import 'preact-material-components/Textfield/style.css';
+import TextField from 'preact-material-components/TextField';
+import 'preact-material-components/TextField/style.css';
 
-export default class TextfieldPage extends Component {
+export default class TextFieldPage extends Component {
   render(){
     return (
       <div>
-        <Textfield multiline={true} label="Textarea tag"/>
+        <TextField label="Textarea tag"/>
       </div>
     );
   }


### PR DESCRIPTION
Some typing fixes / improvements & also some fixes to docs and samples (I'm going through the docs and testing the typings with the samples so found some issues there).

Prop `disabled?: boolean` is redundant, since it's inherited from HTMLAttributes.

There are more coming later, but started this PR already so you can see some progress.

ping @YePpHa can you check this out also?