### PR TITLE
Made all event listeners consistent to always return Event

### DIFF
--- a/Drawer/Drawer.jsx
+++ b/Drawer/Drawer.jsx
@@ -4,7 +4,7 @@ import { MDCTemporaryDrawer } from "@material/drawer/temporary";
 import { MDCPersistentDrawer } from "@material/drawer/persistent";
 import List from "../List";
 
-/*
+/**
  * Default props for drawers
  */
 const defaultProps = {
@@ -18,14 +18,14 @@ class TemporaryDrawer extends MaterialComponent {
     this._open = this._open.bind(this);
     this._close = this._close.bind(this);
   }
-  _open() {
+  _open(e) {
     if (this.props.onOpen) {
-      this.props.onOpen();
+      this.props.onOpen(e);
     }
   }
-  _close() {
+  _close(e) {
     if (this.props.onClose) {
-      this.props.onClose();
+      this.props.onClose(e);
     }
   }
   componentDidMount() {
@@ -155,14 +155,14 @@ class PersistentDrawer extends MaterialComponent {
     this._open = this._open.bind(this);
     this._close = this._close.bind(this);
   }
-  _open() {
+  _open(e) {
     if (this.props.onOpen) {
-      this.props.onOpen();
+      this.props.onOpen(e);
     }
   }
-  _close() {
+  _close(e) {
     if (this.props.onClose) {
-      this.props.onClose();
+      this.props.onClose(e);
     }
   }
   componentDidMount() {
@@ -240,7 +240,7 @@ class DrawerItem extends List.LinkItem {
   }
 }
 
-/*
+/**
  * Function to add declarative opening/closing to drawer
  */
 function toggleDrawer(oldprops, newprops, drawer) {

--- a/Drawer/index.d.ts
+++ b/Drawer/index.d.ts
@@ -17,8 +17,8 @@ export default class Drawer {
 }
 
 declare interface IDrawerProps extends JSX.HTMLAttributes {
-  onOpen?: () => void;
-  onClose?: () => void;
+  onOpen?: (e: Event) => void;
+  onClose?: (e: Event) => void;
 }
 declare class TemporaryDrawer extends MaterialComponent<IDrawerProps, {}> {
   MDComponent: MDCTemporaryDrawer;

--- a/MaterialComponentsWeb.d.ts
+++ b/MaterialComponentsWeb.d.ts
@@ -16,8 +16,10 @@ export declare class MDCComponent<F> {
   getDefaultFoundation(): F;
   initialSyncWithDOM(): void;
   destroy(): void;
-  listen(evtType: string, handler: Function): void;
-  unlisten(evtType: string, handler: Function): void;
+  listen<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any): void;
+  listen(type: string, listener: EventListenerOrEventListenerObject): void;
+  unlisten<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any): void;
+  unlisten(type: string, listener: EventListenerOrEventListenerObject): void;
   emit(evtType: string, evtData: Object, shouldBubble?: boolean): void;
 }
 

--- a/Menu/Menu.jsx
+++ b/Menu/Menu.jsx
@@ -38,21 +38,21 @@ class Menu extends MaterialComponent {
     this.MDComponent.unlisten("MDCSimpleMenu:cancel", this._cancel);
     this.MDComponent.destroy && this.MDComponent.destroy();
   }
-  _select() {
+  _select(e) {
     if (this.props.onSelect) {
-      this.props.onSelect();
+      this.props.onSelect(e);
     }
     this._menuClosed();
   }
-  _cancel() {
+  _cancel(e) {
     if (this.props.onCancel) {
-      this.props.onCancel();
+      this.props.onCancel(e);
     }
     this._menuClosed();
   }
-  _menuClosed() {
+  _menuClosed(e) {
     if (this.props.onMenuClosed) {
-      this.props.onMenuClosed();
+      this.props.onMenuClosed(e);
     }
   }
   componentWillUpdate(nextProps) {

--- a/Menu/index.d.ts
+++ b/Menu/index.d.ts
@@ -9,9 +9,9 @@ declare interface IMenuProps extends JSX.HTMLAttributes {
   'open-from-top-right'?: boolean;
   'open-from-bottom-left'?: boolean;
   'open-from-bottom-right'?: boolean;
-  onSelect?: () => void;
-  onCancel?: () => void;
-  onMenuClosed?: () => void;
+  onSelect?: (e: Event) => void;
+  onCancel?: (e: Event) => void;
+  onMenuClosed?: (e: Event) => void;
 }
 
 export default class Menu extends MaterialComponent<IMenuProps, {}> {

--- a/Slider/Slider.jsx
+++ b/Slider/Slider.jsx
@@ -13,27 +13,36 @@ export default class Slider extends MaterialComponent {
     this._onChange = this._onChange.bind(this);
     this._onInput = this._onInput.bind(this);
   }
-  _onChange() {
+
+  _onChange(e) {
     if (this.props.onChange) {
-      this.props.onChange(this.MDComponent.value);
+      this.props.onChange(e);
     }
   }
-  _onInput() {
+
+  _onInput(e) {
     if (this.props.onInput) {
-      this.props.onInput(this.MDComponent.value);
+      this.props.onInput(e);
     }
   }
+
   componentDidMount() {
     this.MDComponent = new MDCSlider(this.base);
     this.MDComponent.listen("MDCSlider:change", this._onChange);
     this.MDComponent.listen("MDCSlider:input", this._onInput);
     this.setValue(); // set initial value programatically because of error if min is greater than initial max
   }
+
   componentWillUnmount() {
     this.MDComponent.unlisten("MDCSlider:change", this._onChange);
     this.MDComponent.unlisten("MDCSlider:input", this._onInput);
     this.MDComponent.destroy && this.MDComponent.destroy();
   }
+
+  getValue() {
+    return this.MDComponent.value;
+  }
+
   setValue(props = this.props) {
     const { disabled = false, min = 0, max = 100, value, step } = props;
     if (this.MDComponent) {

--- a/Slider/index.d.ts
+++ b/Slider/index.d.ts
@@ -9,13 +9,14 @@ declare interface ISliderProps extends Omit<JSX.HTMLAttributes, 'value' | 'min' 
   min?: number;
   max?: number;
   step?: number;
-  onInput?: (value: number) => void;
-  onChange?: (value: number) => void;
+  onInput?: (e: Event) => void;
+  onChange?: (e: Event) => void;
 }
 
 export default class Slider extends MaterialComponent<ISliderProps, {}> {
   MDComponent: MDCSlider;
   setValue(props: ISliderProps): void;
+  getValue(): number;
 }
 
 declare class MDCSliderFoundation extends MDCFoundation<MDCSlider> {


### PR DESCRIPTION
Resolves: #476.

All the event listeners will now pass the Event object as an argument to make it consistent for all the event listeners.

__Breaking change__
The events `onChange` and `onInput` will pass the event object instead of the value from `MDCComponent`. To still allow easy access to the value of the slider I've added the method `getValue`.