### PR TITLE
List: update css classname of ListSecondaryText

### DIFF
--- a/List/List.jsx
+++ b/List/List.jsx
@@ -163,7 +163,7 @@ class ListPrimaryText extends ListTextContainer {
 class ListSecondaryText extends ListTextContainer {
   constructor() {
     super();
-    this.componentName = "list-item__text__secondary-text";
+    this.componentName = "list-item__secondary-text";
   }
 }
 


### PR DESCRIPTION
It seems the generated css classname for `ListSecondaryText` has been updated from `list-item__text__secondary-text` to `list-item__secondary-text`, which would cause wrong rendering of `ListSecondaryText`.
Might be relevant with these? 
https://github.com/material-components/material-components-web/pull/1877
https://github.com/material-components/material-components-web/pull/1660