### PR TITLE
fix(select): fix some issues with the select component.

### DIFF
--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -31,23 +31,22 @@ class Select extends MaterialComponent {
     }
   }
   updateSelection() {
-    if (
-      "selectedIndex" in this.props &&
-      this.props.selectedIndex != null &&
-      this.MDComponent
-    ) {
-      this.MDComponent.selectedIndex = this.props.selectedIndex;
+    if (!this.MDComponent) return;
+
+    if ("selectedIndex" in this.props) {
+      const selectedIndex =
+        typeof this.props.selectedIndex === "number"
+          ? this.props.selectedIndex
+          : -1;
+
+      this.MDComponent.selectedIndex = selectedIndex;
     }
-    if (this.MDComponent && this.MDComponent.foundation_) {
-      this.MDComponent.foundation_.resize();
-      if (
-        this.props.selectedIndex === null ||
-        this.props.selectedIndex === -1
-      ) {
-        this.MDComponent.foundation_.adapter_.setSelectedTextContent(
-          this.props.hintText
-        );
-      }
+
+    const selectedIndex = this.MDComponent.selectedIndex;
+    if (selectedIndex === -1) {
+      this._labelRef.classList.remove("mdc-select__label--float-above");
+    } else {
+      this._labelRef.classList.add("mdc-select__label--float-above");
     }
   }
   componentDidUpdate() {
@@ -75,19 +74,53 @@ class Select extends MaterialComponent {
           this.control = control;
         }}
       >
-        <div class="mdc-select__surface">
-          <div class="mdc-select__label">{props.hintText}</div>
+        <div class="mdc-select__surface" tabindex="0">
+          <div
+            class="mdc-select__label"
+            ref={ref => {
+              this._labelRef = ref;
+            }}
+          >
+            {props.hintText}
+          </div>
           <div class="mdc-select__selected-text" />
           <div class="mdc-select__bottom-line" />
         </div>
-        <div className="mdc-simple-menu mdc-select__menu">
-          <ul className="mdc-list mdc-simple-menu__items">{props.children}</ul>
+        <div class="mdc-simple-menu mdc-select__menu">
+          <ul class="mdc-list mdc-simple-menu__items">{props.children}</ul>
         </div>
       </div>
     );
   }
 }
 
-Select.Item = List.Item;
+class SelectOption extends List.Item {
+  materialDom(props) {
+    const disabled = "disabled" in props && !!props["disabled"];
+    const selected = "selected" in props && !!props["selected"];
+
+    const baseProps = {
+      tabindex: disabled ? "-1" : "0"
+    };
+    if (disabled) {
+      baseProps["aria-disabled"] = "true";
+    }
+    if (selected) {
+      baseProps["aria-selected"] = "true";
+    }
+
+    props = Object.assign(baseProps, props);
+    if ("disabled" in props) {
+      delete props["disabled"];
+    }
+    if ("selected" in props) {
+      delete props["selected"];
+    }
+
+    return super.materialDom(props);
+  }
+}
+
+Select.Item = SelectOption;
 
 export default Select;

--- a/docs/src/routes/select/index.js
+++ b/docs/src/routes/select/index.js
@@ -29,6 +29,11 @@ export default class SelectPage extends Component {
             description: "Makes the select box CSS only."
           },
           {
+            name: "selectedIndex",
+            value: "number",
+            description: "The option to be set as selected."
+          },
+          {
             name: "hintText",
             value: "string",
             description:
@@ -44,7 +49,17 @@ export default class SelectPage extends Component {
       },
       {
         component: "Select.Item",
-        props: []
+        props: [
+          {
+            name: "disabled",
+            description: "Disables the option."
+          },
+          {
+            name: "selected",
+            description:
+              'Set the option as selected. Mostly the same as "selectedIndex", but it allows selection of multiple options.'
+          }
+        ]
       }
     ];
     this.eventsTable = [
@@ -108,6 +123,14 @@ export default class SelectPage extends Component {
           <Select.Item>Option 1</Select.Item>
           <Select.Item>Option 2</Select.Item>
           <Select.Item>Option 3</Select.Item>
+          <Select.Item>Option 4</Select.Item>
+        </Select>
+
+        <div className="mdc-typography--title">Disabled option </div>
+        <Select hintText="Select">
+          <Select.Item>Option 1</Select.Item>
+          <Select.Item disabled>Option 2</Select.Item>
+          <Select.Item selected>Option 3</Select.Item>
           <Select.Item>Option 4</Select.Item>
         </Select>
 

--- a/sample/home.jsx
+++ b/sample/home.jsx
@@ -281,18 +281,41 @@ export default class Home extends Component {
         </Button>
         <div>
           <Select
-            hintText="Select an option"
-            selectedIndex={this.state.chosenOption}
+            hintText="Pick a Food Group"
+            selectedIndex={4}
             onChange={e => {
               this.setState({
                 chosenOption: e.selectedIndex
               });
             }}
           >
-            <Select.Item>opt1</Select.Item>
-            <Select.Item>opt2</Select.Item>
-            <Select.Item>opt3</Select.Item>
-            <Select.Item>opt4</Select.Item>
+            <Select.Item>Bread, Cereal, Rice, and Pasta</Select.Item>
+            <Select.Item disabled>Vegetables</Select.Item>
+            <Select.Item>Fruit</Select.Item>
+            <Select.Item>Milk, Yogurt, and Cheese</Select.Item>
+            <Select.Item>
+              Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts
+            </Select.Item>
+            <Select.Item>Fats, Oils, and Sweets</Select.Item>
+          </Select>
+        </div>
+        <div>
+          <Select
+            hintText="Pick a Food Group"
+            onChange={e => {
+              this.setState({
+                chosenOption: e.selectedIndex
+              });
+            }}
+          >
+            <Select.Item>Bread, Cereal, Rice, and Pasta</Select.Item>
+            <Select.Item disabled>Vegetables</Select.Item>
+            <Select.Item>Fruit</Select.Item>
+            <Select.Item selected>Milk, Yogurt, and Cheese</Select.Item>
+            <Select.Item>
+              Meat, Poultry, Fish, Dry Beans, Eggs, and Nuts
+            </Select.Item>
+            <Select.Item>Fats, Oils, and Sweets</Select.Item>
           </Select>
         </div>
 

--- a/sample/webpack.config.js
+++ b/sample/webpack.config.js
@@ -4,7 +4,7 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 
 const config = {
   entry: {
-    app: "./app.jsx",
+    app: path.join(__dirname, "./app.jsx"),
     vendor: ["preact"]
   },
   output: {


### PR DESCRIPTION
Resolves: [#552](https://github.com/prateekbh/preact-material-components/issues/552)

Changes:
- Add `selected` and `disabled` props to the select options (extended ListItem as it's not feature of ListItem).
- Update some of the HTML elements to include the `tabindex` attribute (see https://github.com/material-components/material-components-web/blob/master/packages/mdc-select/README.md).
- `mdc-select__label--float-above` is added to the select label (`hintText`) whenever `selectedIndex` is not `-1` and removes it if it's `-1`. This fix should be removed when [material-components-web#1810](https://github.com/material-components/material-components-web/issues/1810) has been resolved.
- Remove the code that calls `setSelectedTextContent()` as it's not needed anymore.

I've also updated the docs with the changes.