### PR TITLE
v30 Update components to include the breaking changes

### DIFF
--- a/Checkbox/Checkbox.jsx
+++ b/Checkbox/Checkbox.jsx
@@ -50,7 +50,7 @@ export default class Checkbox extends MaterialComponent {
             viewBox="0 0 24 24"
           >
             <path
-              className="mdc-checkbox__checkmark__path"
+              className="mdc-checkbox__checkmark-path"
               fill="none"
               stroke="white"
               d="M1.73,12.91 8.1,19.28 22.79,4.59"

--- a/Menu/Menu.jsx
+++ b/Menu/Menu.jsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 import MaterialComponent from "../MaterialComponent";
-import { MDCSimpleMenu } from "@material/menu";
+import { MDCMenu } from "@material/menu";
 import List from "../List";
 
 /*
@@ -16,7 +16,7 @@ const defaultProps = {
 class Menu extends MaterialComponent {
   constructor() {
     super();
-    this.componentName = "simple-menu";
+    this.componentName = "menu";
     this._mdcProps = [
       "open",
       "open-from-top-left",
@@ -28,14 +28,14 @@ class Menu extends MaterialComponent {
     this._cancel = this._cancel.bind(this);
   }
   componentDidMount() {
-    this.MDComponent = new MDCSimpleMenu(this.control);
-    this.MDComponent.listen("MDCSimpleMenu:selected", this._select);
-    this.MDComponent.listen("MDCSimpleMenu:cancel", this._cancel);
+    this.MDComponent = new MDCMenu(this.control);
+    this.MDComponent.listen("MDCMenu:selected", this._select);
+    this.MDComponent.listen("MDCMenu:cancel", this._cancel);
     toggleMenu(defaultProps, this.props, this.MDComponent);
   }
   componentWillUnmount() {
-    this.MDComponent.unlisten("MDCSimpleMenu:selected", this._select);
-    this.MDComponent.unlisten("MDCSimpleMenu:cancel", this._cancel);
+    this.MDComponent.unlisten("MDCMenu:selected", this._select);
+    this.MDComponent.unlisten("MDCMenu:cancel", this._cancel);
     this.MDComponent.destroy && this.MDComponent.destroy();
   }
   _select(e) {
@@ -61,13 +61,9 @@ class Menu extends MaterialComponent {
   materialDom(props) {
     return (
       <div tabindex="-1" {...props} ref={control => (this.control = control)}>
-        <ul
-          class="mdc-simple-menu__items mdc-list"
-          role="menu"
-          aria-hidden="true"
-        >
+        <List className="mdc-menu__items" role="menu" aria-hidden="true">
           {props.children}
-        </ul>
+        </List>
       </div>
     );
   }

--- a/Menu/index.d.ts
+++ b/Menu/index.d.ts
@@ -18,16 +18,16 @@ export default class Menu extends MaterialComponent<IMenuProps, {}> {
   static Anchor: typeof Anchor;
   static Item: typeof List.Item;
 
-  MDComponent: MDCSimpleMenu;
+  MDComponent: MDCMenu;
 }
 
 declare class Anchor extends MaterialComponent<JSX.HTMLAttributes, {}> {}
 
-declare class MDCSimpleMenuFoundation extends MDCFoundation<MDCSimpleMenu> {
+declare class MDCMenuFoundation extends MDCFoundation<MDCMenu> {
   open(options?: { focusIndex?: number }): void;
   close(evt?: Event): void;
 }
-declare class MDCSimpleMenu extends MDCComponent<MDCSimpleMenuFoundation> {
+declare class MDCMenu extends MDCComponent<MDCMenuFoundation> {
   open: boolean;
   show(options?: { focusIndex?: number }): void;
   hide(): void;

--- a/Select/Select.jsx
+++ b/Select/Select.jsx
@@ -2,11 +2,12 @@ import { h } from "preact";
 import MaterialComponent from "../MaterialComponent";
 import { MDCSelect } from "@material/select/";
 import List from "../List";
+import Menu from "../Menu";
 class Select extends MaterialComponent {
   constructor() {
     super();
     this.componentName = "select";
-    this._mdcProps = ["disabled"];
+    this._mdcProps = ["disabled", "box"];
     this._changed = this._changed.bind(this);
   }
   _changed(e) {
@@ -18,21 +19,15 @@ class Select extends MaterialComponent {
     }
   }
   componentDidMount() {
-    if (!this.props.basic) {
-      this.MDComponent = new MDCSelect(this.control);
-      this.MDComponent.listen("MDCSelect:change", this._changed);
-      this.updateSelection();
-    }
+    this.MDComponent = new MDCSelect(this.base);
+    this.MDComponent.listen("MDCSelect:change", this._changed);
+    this.updateSelection();
   }
   componentWillUnmount() {
-    if (!this.props.basic) {
-      this.MDComponent.unlisten("MDCSelect:change", this._changed);
-      this.MDComponent.destroy && this.MDComponent.destroy();
-    }
+    this.MDComponent.unlisten("MDCSelect:change", this._changed);
+    this.MDComponent.destroy && this.MDComponent.destroy();
   }
   updateSelection() {
-    if (!this.MDComponent) return;
-
     if ("selectedIndex" in this.props) {
       const selectedIndex =
         typeof this.props.selectedIndex === "number"
@@ -53,27 +48,8 @@ class Select extends MaterialComponent {
     this.updateSelection();
   }
   materialDom(props) {
-    if (props.basic) {
-      return (
-        <select
-          {...props}
-          ref={control => {
-            this.control = control;
-          }}
-        >
-          {props.children}
-        </select>
-      );
-    }
-
     return (
-      <div
-        role="listbox"
-        {...props}
-        ref={control => {
-          this.control = control;
-        }}
-      >
+      <div role="listbox" {...props}>
         <div class="mdc-select__surface" tabindex="0">
           <div
             class="mdc-select__label"
@@ -86,9 +62,7 @@ class Select extends MaterialComponent {
           <div class="mdc-select__selected-text" />
           <div class="mdc-select__bottom-line" />
         </div>
-        <div class="mdc-simple-menu mdc-select__menu">
-          <ul class="mdc-list mdc-simple-menu__items">{props.children}</ul>
-        </div>
+        <Menu className="mdc-select__menu">{props.children}</Menu>
       </div>
     );
   }

--- a/Select/index.d.ts
+++ b/Select/index.d.ts
@@ -6,7 +6,7 @@ import { Omit } from '../libs';
 
 declare interface ISelectProps extends Omit<JSX.HTMLAttributes, 'onChange' | 'disabled'> {
   disabled?: boolean;
-  basic?: boolean;
+  box?: boolean;
   hintText?: string;
   selectedIndex?: number;
   onChange?: (e: { selectedIndex: number, selectedOptions: NodeListOf<Element> }) => void;

--- a/sample/home.jsx
+++ b/sample/home.jsx
@@ -35,7 +35,7 @@ export default class Home extends Component {
       progress: 0.2
     };
   }
-  render() {
+  render({}, state) {
     const toggleOnIcon = {
       content: "favorite",
       label: "Remove From Favorites"
@@ -281,11 +281,13 @@ export default class Home extends Component {
         <Button raised onClick={() => this.setState({ chosenOption: -1 })}>
           Clear Select
         </Button>
+        <div>Selected index: {state.chosenOption}</div>
         <div>
           <Select
             hintText="Pick a Food Group"
-            selectedIndex={4}
+            selectedIndex={state.chosenOption}
             onChange={e => {
+              console.log(e.selectedIndex);
               this.setState({
                 chosenOption: e.selectedIndex
               });
@@ -302,14 +304,7 @@ export default class Home extends Component {
           </Select>
         </div>
         <div>
-          <Select
-            hintText="Pick a Food Group"
-            onChange={e => {
-              this.setState({
-                chosenOption: e.selectedIndex
-              });
-            }}
-          >
+          <Select hintText="Pick a Food Group">
             <Select.Item>Bread, Cereal, Rice, and Pasta</Select.Item>
             <Select.Item disabled>Vegetables</Select.Item>
             <Select.Item>Fruit</Select.Item>


### PR DESCRIPTION
See [v0.30.0/CHANGELOG.md](https://github.com/material-components/material-components-web/blob/v0.30.0/CHANGELOG.md) for the breaking changes.

__Changes:__

_Select_
- Remove the `basic` prop as the css version of `mdc-select` element has been removed.
- Add `box` prop.
- Replace `.mdc-select__menu` with the `Menu` component.

_Menu_
- Change the value of componentName to `menu`.
- Change all references of `MDCSimpleMenu` to `MDCMenu`.
- Change `MDCSimpleMenu:selected` to `MDCMenu:selected`.
- Change `MDCSimpleMenu:cancel` to `MDCMenu:cancel`.
- Replace `.mdc-simple-menu` with `.mdc-menu`.
- Replace `.mdc-simple-menu__items` with `.mdc-menu__items`.
- Replace `.mdc-menu__items` with the `List` component.

_Checkbox_
- Replace `mdc-checkbox__checkmark__path` with `mdc-checkbox__checkmark-path`.