### PR TITLE
Add disabled class to TextField

### DIFF
--- a/TextField/TextField.jsx
+++ b/TextField/TextField.jsx
@@ -85,6 +85,10 @@ class TextFieldInput extends MaterialComponent {
     if ('trailingIcon' in props) {
       className += ' mdc-text-field--box mdc-text-field--with-trailing-icon';
     }
+    
+    if ('disabled' in props && props.disabled) {
+      className += ' mdc-text-field--disabled';
+    }
 
     if ('value' in props && this.state.showFloatingLabel) {
       className = [className, 'mdc-text-field--upgraded'].join(' ');


### PR DESCRIPTION
Disabled text fields are actually supposed to have an extra class on the field wrapper. This PR just adds `mdc-text-field--disabled` class if `disabled` prop is truthy.