### PR TITLE
Remvoed componentWillUnmount from Chip as there's no MDComponent created

### DIFF
--- a/Chips/Chips.jsx
+++ b/Chips/Chips.jsx
@@ -35,10 +35,6 @@ class Chip extends MaterialComponent {
     this.componentName = 'chip';
   }
 
-  componentWillUnmount() {
-    this.MDComponent.destroy && this.MDComponent.destroy();
-  }
-
   materialDom(allprops) {
     const {children, ...props} = allprops;
 


### PR DESCRIPTION
Am getting issues using the <Chip /> in that the componentWillUnmount is trying to ref .destroy on this.MDComponent, but this.MDComponent isn't created for this component any more - it was removed in a previous commit.

Just removed componentWillUnmount from the component as it's not required any more.