### PR TITLE
Added valid to TextFieldProps

### DIFF
--- a/docs/src/routes/card/index.js
+++ b/docs/src/routes/card/index.js
@@ -92,7 +92,9 @@ export default class CardPage extends Component {
           </Card.Actions>
         </Card>
 
-        <div className="mdc-typography--display1">Card with full-bleed action area</div>
+        <div className="mdc-typography--display1">
+          Card with full-bleed action area
+        </div>
         <Card>
           <div class="card-header">
             <h2 class=" mdc-typography--title">Title</h2>

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -208,6 +208,7 @@ export interface ITextFieldProps extends JSX.HTMLAttributes {
   box?: boolean;
   disabled?: boolean;
   outlined?: boolean;
+  valid?: boolean; // TODO: Add to docs
   helperText?: string;
   helperTextPersistent?: boolean;
   helperTextValidationMsg?: boolean;


### PR DESCRIPTION
As #873 is still under consideration and needs rework for the new build system, this aims at fixing the `valid` prop for TypeScript.