### PR TITLE
Proper refs for TextField and ref typing

### DIFF
--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -1,9 +1,11 @@
 import MDCComponent from '@material/base/component';
+import MDCFoundation from '@material/base/foundation';
 import autobind from 'autobind-decorator';
 import MaterialComponent from './MaterialComponent';
 
 export abstract class InputComponent<
-  M extends MDCComponent<any, any> & {value: string},
+  M extends MDCComponent<any, F>,
+  F extends MDCFoundation<any> & {getValue(): string},
   PropType,
   StateType
 > extends MaterialComponent<PropType, StateType> {
@@ -20,8 +22,8 @@ export abstract class InputComponent<
   }
 
   public get value(): string | undefined {
-    if (this.MDComponent && this.MDComponent.value) {
-      return this.MDComponent.value;
+    if (this.MDComponent) {
+      return this.MDComponent.getDefaultFoundation().getValue();
     } else if (this.inputRef) {
       return this.inputRef.value;
     }

--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -33,3 +33,5 @@ export abstract class InputComponent<
     this.inputRef = ref;
   }
 }
+
+export default InputComponent;

--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -1,0 +1,37 @@
+import MDCComponent from '@material/base/component';
+import autobind from 'autobind-decorator';
+import MaterialComponent from './MaterialComponent';
+
+export abstract class InputComponent<
+  M extends MDCComponent<any, any> & {value: string},
+  PropType,
+  StateType
+> extends MaterialComponent<PropType, StateType> {
+  protected inputRef?: HTMLInputElement;
+  protected MDComponent?: M;
+
+  @autobind
+  public getMDComponent(): M | undefined {
+    return this.MDComponent;
+  }
+
+  @autobind
+  public get input(): HTMLInputElement | undefined {
+    return this.inputRef;
+  }
+
+  @autobind
+  public get value(): string | undefined {
+    if (this.MDComponent && this.MDComponent.value) {
+      return this.MDComponent.value;
+    } else if (this.inputRef) {
+      return this.inputRef.value;
+    }
+    return;
+  }
+
+  @autobind
+  protected setInputRef(ref?: HTMLInputElement) {
+    this.inputRef = ref;
+  }
+}

--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -17,6 +17,9 @@ export abstract class InputComponent<
     return this.MDComponent;
   }
 
+  /**
+   * Warning: Experimental
+   */
   public get input(): HTMLInputElement | undefined {
     return this.inputRef;
   }

--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -15,12 +15,10 @@ export abstract class InputComponent<
     return this.MDComponent;
   }
 
-  @autobind
   public get input(): HTMLInputElement | undefined {
     return this.inputRef;
   }
 
-  @autobind
   public get value(): string | undefined {
     if (this.MDComponent && this.MDComponent.value) {
       return this.MDComponent.value;

--- a/ts/Base/InputComponent.ts
+++ b/ts/Base/InputComponent.ts
@@ -1,11 +1,9 @@
 import MDCComponent from '@material/base/component';
-import MDCFoundation from '@material/base/foundation';
 import autobind from 'autobind-decorator';
 import MaterialComponent from './MaterialComponent';
 
 export abstract class InputComponent<
-  M extends MDCComponent<any, F>,
-  F extends MDCFoundation<any> & {getValue(): string},
+  M extends MDCComponent<any, any> & {value: string},
   PropType,
   StateType
 > extends MaterialComponent<PropType, StateType> {
@@ -26,7 +24,7 @@ export abstract class InputComponent<
 
   public get value(): string | undefined {
     if (this.MDComponent) {
-      return this.MDComponent.getDefaultFoundation().getValue();
+      return this.MDComponent.value;
     } else if (this.inputRef) {
       return this.inputRef.value;
     }

--- a/ts/Base/MaterialComponent.ts
+++ b/ts/Base/MaterialComponent.ts
@@ -1,3 +1,4 @@
+import MDCComponent from '@material/base/component';
 import {MDCRipple} from '@material/ripple';
 import autobind from 'autobind-decorator';
 import {Component, VNode} from 'preact';
@@ -36,13 +37,29 @@ export abstract class MaterialComponent<
    */
   protected abstract mdcProps: string[];
   /** This will again be used to add apt classname to the component */
-  protected abstract componentName: string;
+  protected abstract readonly componentName: string;
 
   /** The final class name given to the dom */
   protected classText?: string | null;
   protected ripple?: MDCRipple | null;
 
   protected control?: Element;
+  protected MDComponent?: MDCComponent<any, any>;
+
+  @autobind
+  public getMDComponent() {
+    return this.MDComponent;
+  }
+
+  @autobind
+  public getComponentName() {
+    return this.componentName;
+  }
+
+  @autobind
+  public getControl() {
+    return this.control;
+  }
 
   public render(props): VNode {
     if (!this.classText) {

--- a/ts/Base/MaterialComponent.ts
+++ b/ts/Base/MaterialComponent.ts
@@ -2,7 +2,7 @@ import MDCComponent from '@material/base/component';
 import {MDCRipple} from '@material/ripple';
 import autobind from 'autobind-decorator';
 import {Component, VNode} from 'preact';
-import {SoftMerge} from './types';
+import {Ref, SoftMerge} from './types';
 
 export interface IMaterialComponentOwnProps {
   ripple?: boolean;
@@ -32,7 +32,14 @@ export abstract class MaterialComponent<
   PropType extends {[prop: string]: any},
   StateType extends {[prop: string]: any}
 > extends Component<
-  MaterialComponentProps<PropType>,
+  MaterialComponentProps<PropType> & {
+    ref?: Ref<
+      MaterialComponent<
+        MaterialComponentProps<PropType>,
+        MaterialComponentState<StateType>
+      >
+    >;
+  },
   MaterialComponentState<StateType>
 > {
   /**

--- a/ts/Base/types.ts
+++ b/ts/Base/types.ts
@@ -9,3 +9,5 @@ export type OmitAttrs<
   T extends {[attr: string]: any},
   O extends {[attr: string]: any}
 > = Pick<T, Diff<keyof T, keyof O>>;
+
+export type Ref<C> = (ref?: C) => void;

--- a/ts/Checkbox/index.tsx
+++ b/ts/Checkbox/index.tsx
@@ -1,15 +1,8 @@
 import {MDCCheckbox} from '@material/checkbox/';
+import MDCCheckboxFoundation from '@material/checkbox/foundation';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
 import InputComponent from '../Base/InputComponent';
-
-/*
- * Default props for check box
- */
-const defaultProps = {
-  checked: false,
-  indeterminate: false
-};
 
 export interface ICheckboxProps {
   indeterminate?: boolean;
@@ -22,6 +15,7 @@ export interface ICheckboxState {}
 
 export class Checkbox extends InputComponent<
   MDCCheckbox,
+  MDCCheckboxFoundation,
   ICheckboxProps,
   ICheckboxState
 > {

--- a/ts/Checkbox/index.tsx
+++ b/ts/Checkbox/index.tsx
@@ -1,7 +1,7 @@
 import {MDCCheckbox} from '@material/checkbox/';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
-import MaterialComponent from '../Base/MaterialComponent';
+import InputComponent from '../Base/InputComponent';
 
 /*
  * Default props for check box
@@ -20,7 +20,8 @@ export interface ICheckboxProps {
 
 export interface ICheckboxState {}
 
-export class Checkbox extends MaterialComponent<
+export class Checkbox extends InputComponent<
+  MDCCheckbox,
   ICheckboxProps,
   ICheckboxState
 > {
@@ -54,6 +55,7 @@ export class Checkbox extends MaterialComponent<
         <input
           type="checkbox"
           className="mdc-checkbox__native-control"
+          ref={this.setInputRef}
           {...allprops}
         />
         <div className="mdc-checkbox__background">

--- a/ts/Checkbox/index.tsx
+++ b/ts/Checkbox/index.tsx
@@ -15,7 +15,6 @@ export interface ICheckboxState {}
 
 export class Checkbox extends InputComponent<
   MDCCheckbox,
-  MDCCheckboxFoundation,
   ICheckboxProps,
   ICheckboxState
 > {

--- a/ts/Radio/index.tsx
+++ b/ts/Radio/index.tsx
@@ -1,7 +1,7 @@
 import {MDCRadio} from '@material/radio/';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
-import MaterialComponent from '../Base/MaterialComponent';
+import InputComponent from '../Base/InputComponent';
 
 export interface IRadioProps {
   checked?: boolean;
@@ -10,7 +10,7 @@ export interface IRadioProps {
 
 export interface IRadioState {}
 
-export class Radio extends MaterialComponent<IRadioProps, IRadioState> {
+export class Radio extends InputComponent<MDCRadio, IRadioProps, IRadioState> {
   protected componentName = 'radio';
   protected mdcProps = ['disabled'];
   protected MDComponent?: MDCRadio;
@@ -45,7 +45,12 @@ export class Radio extends MaterialComponent<IRadioProps, IRadioState> {
     const {className, ...props} = allprops;
     return (
       <div className={className} ref={this.setControlRef}>
-        <input className="mdc-radio__native-control" type="radio" {...props} />
+        <input
+          className="mdc-radio__native-control"
+          type="radio"
+          {...props}
+          ref={this.setInputRef}
+        />
         <div className="mdc-radio__background">
           <div className="mdc-radio__outer-circle" />
           <div className="mdc-radio__inner-circle" />

--- a/ts/Radio/index.tsx
+++ b/ts/Radio/index.tsx
@@ -11,12 +11,7 @@ export interface IRadioProps {
 
 export interface IRadioState {}
 
-export class Radio extends InputComponent<
-  MDCRadio,
-  MDCRadioFoundation,
-  IRadioProps,
-  IRadioState
-> {
+export class Radio extends InputComponent<MDCRadio, IRadioProps, IRadioState> {
   protected componentName = 'radio';
   protected mdcProps = ['disabled'];
   protected MDComponent?: MDCRadio;

--- a/ts/Radio/index.tsx
+++ b/ts/Radio/index.tsx
@@ -1,4 +1,5 @@
 import {MDCRadio} from '@material/radio/';
+import MDCRadioFoundation from '@material/radio/foundation';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
 import InputComponent from '../Base/InputComponent';
@@ -10,7 +11,12 @@ export interface IRadioProps {
 
 export interface IRadioState {}
 
-export class Radio extends InputComponent<MDCRadio, IRadioProps, IRadioState> {
+export class Radio extends InputComponent<
+  MDCRadio,
+  MDCRadioFoundation,
+  IRadioProps,
+  IRadioState
+> {
   protected componentName = 'radio';
   protected mdcProps = ['disabled'];
   protected MDComponent?: MDCRadio;

--- a/ts/Switch/index.tsx
+++ b/ts/Switch/index.tsx
@@ -1,4 +1,5 @@
 import {MDCSwitch} from '@material/switch';
+import {MDCSwitchFoundation} from '@material/switch/foundation';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
 import InputComponent from '../Base/InputComponent';
@@ -11,6 +12,7 @@ export interface ISwitchState {}
 
 export class Switch extends InputComponent<
   MDCSwitch,
+  MDCSwitchFoundation,
   ISwitchProps,
   ISwitchState
 > {

--- a/ts/Switch/index.tsx
+++ b/ts/Switch/index.tsx
@@ -1,7 +1,7 @@
 import {MDCSwitch} from '@material/switch';
 import autobind from 'autobind-decorator';
 import {h} from 'preact';
-import MaterialComponent from '../Base/MaterialComponent';
+import InputComponent from '../Base/InputComponent';
 
 export interface ISwitchProps extends JSX.HTMLAttributes {
   disabled?: boolean;
@@ -9,7 +9,11 @@ export interface ISwitchProps extends JSX.HTMLAttributes {
 
 export interface ISwitchState {}
 
-export class Switch extends MaterialComponent<ISwitchProps, ISwitchState> {
+export class Switch extends InputComponent<
+  MDCSwitch,
+  ISwitchProps,
+  ISwitchState
+> {
   protected componentName = 'switch';
   protected mdcProps = ['disabled'];
   protected MDComponent?: MDCSwitch;
@@ -41,6 +45,7 @@ export class Switch extends MaterialComponent<ISwitchProps, ISwitchState> {
               id="basic-switch"
               class="mdc-switch__native-control"
               role="switch"
+              ref={this.setInputRef}
               {...props}
             />
           </div>

--- a/ts/Switch/index.tsx
+++ b/ts/Switch/index.tsx
@@ -12,7 +12,6 @@ export interface ISwitchState {}
 
 export class Switch extends InputComponent<
   MDCSwitch,
-  MDCSwitchFoundation,
   ISwitchProps,
   ISwitchState
 > {

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -69,7 +69,6 @@ export interface ITextFieldInputState {
 
 export class TextFieldInput extends InputComponent<
   MDCTextField,
-  MDCTextFieldFoundation,
   ITextFieldInputProps,
   ITextFieldInputState
 > {

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -1,7 +1,7 @@
 import {MDCTextField} from '@material/textfield';
 import autobind from 'autobind-decorator';
 import {Component, h} from 'preact';
-import {InputComponent} from '../Base/InputComponent';
+import InputComponent from '../Base/InputComponent';
 import MaterialComponent from '../Base/MaterialComponent';
 import {OmitAttrs, Ref} from '../Base/types';
 import Icon from '../Icon';

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -1,4 +1,5 @@
 import {MDCTextField} from '@material/textfield';
+import MDCTextFieldFoundation from '@material/textfield/foundation';
 import autobind from 'autobind-decorator';
 import {Component, h} from 'preact';
 import InputComponent from '../Base/InputComponent';
@@ -68,6 +69,7 @@ export interface ITextFieldInputState {
 
 export class TextFieldInput extends InputComponent<
   MDCTextField,
+  MDCTextFieldFoundation,
   ITextFieldInputProps,
   ITextFieldInputState
 > {

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -101,9 +101,6 @@ export class TextFieldInput extends InputComponent<
       () => {
         if (this.control) {
           this.MDComponent = new MDCTextField(this.control);
-          if (this.props.onInit) {
-            this.props.onInit(this.MDComponent);
-          }
           if (this.props.value) {
             this.MDComponent.value = this.props.value;
           }

--- a/ts/TextField/index.tsx
+++ b/ts/TextField/index.tsx
@@ -242,7 +242,6 @@ export class TextField extends Component<
 
   protected readonly id = TextField.uid();
 
-  @autobind
   public get MDComponent(): MDCTextField | undefined {
     if (this.inputRef) {
       return this.inputRef.getMDComponent();
@@ -251,7 +250,6 @@ export class TextField extends Component<
 
   protected inputRef?: TextFieldInput;
 
-  @autobind
   public get tfInput(): TextFieldInput | undefined {
     return this.inputRef;
   }


### PR DESCRIPTION
- [x] `TextField` refs can properly access `TextFieldInput`
- [x] All Elements that are wrappers around an `<input>` element allow access to a reference of that input element
- [ ] Type all refs

A ref of `TextFieldInput` can be accessed via
``` typescript
text_field_ref.tfInput
```

Input refs will be accessible via
``` typescript
ref.input
```