### PR TITLE
Fixed the select onchange method typings

### DIFF
--- a/ts/Select/index.tsx
+++ b/ts/Select/index.tsx
@@ -29,7 +29,7 @@ export interface ISelectProps {
   hintText?: string;
   selectedIndex?: number;
 
-  onChange?: (e: Event & {selectedIndex: number}) => void;
+  onChange?: (e: Event & {target: EventTarget & {selectedIndex: number}}) => void;
 }
 
 export interface ISelectState {}

--- a/ts/Select/index.tsx
+++ b/ts/Select/index.tsx
@@ -29,7 +29,9 @@ export interface ISelectProps {
   hintText?: string;
   selectedIndex?: number;
 
-  onChange?: (e: Event & {target: EventTarget & {selectedIndex: number}}) => void;
+  onChange?: (
+    e: Event & {target: EventTarget & {selectedIndex: number}}
+  ) => void;
 }
 
 export interface ISelectState {}


### PR DESCRIPTION
selectedIndex is provided on e.target.selectedIndex, but the typings said it should be accessed through e.selectedIndex, thus not compiling when accessing e.target.selectedIndex