### PR TITLE
Switch: Use mdcNotifyProps

### DIFF
--- a/ts/Switch/index.tsx
+++ b/ts/Switch/index.tsx
@@ -12,20 +12,12 @@ export class Switch extends MaterialComponent<ISwitchProps, ISwitchState> {
   public MDComponent?: MDCSwitch;
   protected componentName = 'switch';
   protected mdcProps = ['disabled', 'checked'];
+  protected mdcNotifyProps = ['disabled', 'checked'];
 
   public componentDidMount() {
     super.componentDidMount();
     if (this.control) {
       this.MDComponent = new MDCSwitch(this.control);
-      if (this.props.value) {
-        this.MDComponent.value = this.props.value;
-      }
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: ISwitchProps) {
-    if (nextProps.value && this.props.value !== nextProps.value) {
-      this.MDComponent.value = nextProps.value;
     }
   }
 


### PR DESCRIPTION
I've removed all updates of `MDComponent.value`, and used `mdcNotifyProps` instead, to make the switch respond to the change of `props.disabled` and `props.checked`.
I'm not sure why `MDComponent.value` is updated here, it is neither existing here in `@material/switch` nor documented.
https://github.com/material-components/material-components-web/blob/master/packages/mdc-switch/index.js

Correct me if I'm wrong.

fixes #1189