### PR TITLE
Get docs working in windows

### DIFF
--- a/packages/base/build/index.ts
+++ b/packages/base/build/index.ts
@@ -1,5 +1,5 @@
 import {statSync} from 'fs';
-import {basename, dirname, join, resolve} from 'path';
+import {basename, dirname, join, resolve, sep} from 'path';
 
 function isFile(file: string) {
   try {
@@ -72,12 +72,12 @@ function findInModules(modsPath: string, url: string) {
 }
 
 function nodeResolveSass(url: string, prev: string) {
-  const prevDir = dirname(prev);
-  const count = prevDir.split('/').length;
+  const prevDir = dirname(resolve(prev));
+  const count = prevDir.split(sep).length;
   for (let i = 0; i < count; i++) {
     const pars = Array.from(Array(i).keys())
       .map(() => '..')
-      .join('/');
+      .join(sep);
     const searchPath = resolve(prevDir, pars, 'node_modules');
     if (isDir(searchPath)) {
       const result = findInModules(searchPath, url);

--- a/packages/docs/preact.config.js
+++ b/packages/docs/preact.config.js
@@ -1,4 +1,4 @@
-import {sassResolver} from '@preact-material-components/base/build';
+const {sassResolver} = require('@preact-material-components/base/build');
 
 /**
  * Function that mutates original webpack config.
@@ -8,7 +8,7 @@ import {sassResolver} from '@preact-material-components/base/build';
  * @param {object} env - options passed to CLI.
  * @param {WebpackConfigHelpers} helpers - object with useful helpers when working with config.
  **/
-export default function(config, env, helpers) {
+module.exports = function(config, env, helpers) {
   for (const {loader} of helpers.getLoadersByName(config, 'proxy-loader')) {
     if (loader.options && loader.options.options && loader.options.loader) {
       if (loader.options.loader === 'sass-loader') {
@@ -22,4 +22,4 @@ export default function(config, env, helpers) {
     }
     loader.options.importer = sassResolver;
   }
-}
+};


### PR DESCRIPTION
Fixes #1283 
- Fixes the `sass-resolver` for windows.
- Also import/export for `preact.config.js` didn't work in windows so used node style exports.