### PR TITLE
Dialog: change to dialog element

### DIFF
--- a/ts/Dialog/index.tsx
+++ b/ts/Dialog/index.tsx
@@ -132,10 +132,10 @@ export class Dialog extends MaterialComponent<IDialogProps, IDialogState> {
 
   protected materialDom(props) {
     return (
-      <aside role={'alertdialog'} ref={this.setControlRef} {...props}>
+      <dialog role={'alertdialog'} ref={this.setControlRef} {...props}>
         <div className="mdc-dialog__surface">{props.children}</div>
         <div className="mdc-dialog__backdrop" />
-      </aside>
+      </dialog>
     );
   }
 }


### PR DESCRIPTION
According to https://github.com/dequelabs/axe-core/blame/develop/lib/commons/aria/index.js#L279
an alertdialog should be of element type dialog or section.

Closes #1288 