### PR TITLE
2.0 dialog axe compliant

### DIFF
--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -50,10 +50,10 @@ export class Dialog extends MaterialComponent<IDialogProps, IDialogState> {
 
   protected materialDom(props) {
     return (
-      <dialog role={'alertdialog'} ref={this.setControlRef} {...props}>
+      <aside role={'alertdialog'} ref={this.setControlRef} {...props}>
         <div className="mdc-dialog__surface">{props.children}</div>
         <div className="mdc-dialog__backdrop" />
-      </dialog>
+      </aside>
     );
   }
 }

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -50,10 +50,10 @@ export class Dialog extends MaterialComponent<IDialogProps, IDialogState> {
 
   protected materialDom(props) {
     return (
-      <aside role={'alertdialog'} ref={this.setControlRef} {...props}>
+      <section role={'alertdialog'} ref={this.setControlRef} {...props}>
         <div className="mdc-dialog__surface">{props.children}</div>
         <div className="mdc-dialog__backdrop" />
-      </aside>
+      </section>
     );
   }
 }


### PR DESCRIPTION
Successor of https://github.com/prateekbh/preact-material-components/pull/1289

Before we merge this. From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section):

- Each <section> should be identified, typically by including a heading (`<h1>`-`<h6>` element) as a child of the <section> element.
- **Do not use the <section> element as a generic container**; this is what `<div>` is for, especially when the sectioning is only for styling purposes. A rule of thumb is that a section should logically appear in the outline of a document.

But that's just opinions (?), while the specs says that aria-role alertdialog must only be on `dialog` or `section` elements, so I guess that's the heaviest part.