### PR TITLE
fix: setLabelRef

### DIFF
--- a/packages/select/src/basic-select.tsx
+++ b/packages/select/src/basic-select.tsx
@@ -88,7 +88,11 @@ export class BasicSelect extends MaterialComponent<
         <div class="mdc-notched-outline">
           <div class="mdc-notched-outline__leading" />
           <div class="mdc-notched-outline__notch">
-            {label && <label class="mdc-floating-label">{label}</label>}
+            {label && (
+              <label class="mdc-floating-label" ref={this.setLabelRef}>
+                {label}
+              </label>
+            )}
           </div>
           <div class="mdc-notched-outline__trailing" />
         </div>
@@ -110,9 +114,13 @@ export class BasicSelect extends MaterialComponent<
         </select>
         {this.getDecorator({outlined, label})}
         {!outlined && label && (
-          <label class="mdc-floating-label">{label}</label>
+          <label class="mdc-floating-label" ref={this.setLabelRef}>
+            {label}
+          </label>
         )}
       </div>
     );
   }
+
+  private setLabelRef = el => (this.labelRef = el);
 }


### PR DESCRIPTION
There is no setter of labelRef.
So labelRef is always `undefined`, and cannot executive this code:
```
protected updateSelection() {
      ...

      const selectedIndex = this.MDComponent.selectedIndex;
      if (selectedIndex === 0) {
        if (this.labelRef) {
          this.labelRef.classList.remove('mdc-floating-label--float-above');
        }
      } else {
        if (this.labelRef) {
          this.labelRef.classList.add('mdc-floating-label--float-above');
        }
      }
    }
  }
```
So I fix it!

before:
![image](https://user-images.githubusercontent.com/20078201/71460893-0902c700-27f1-11ea-8d8f-8952eb8f5c3a.png)

after:
![image](https://user-images.githubusercontent.com/20078201/71460926-35b6de80-27f1-11ea-8b4f-c2bf369028cc.png)
